### PR TITLE
Includes files to set up supervisor

### DIFF
--- a/EAPImgRotnWebApp.conf
+++ b/EAPImgRotnWebApp.conf
@@ -1,0 +1,12 @@
+[program:EAPImgRotnWebApp]
+command=sh /var/www/EAPImgRotnWebApp/startServer.sh
+environment=PYTHONPATH=/home/ubuntu/.local/lib/python3.6/site-packages
+directory=/var/www/EAPImgRotnWebApp
+startsecs=0
+autostart=true
+autorestart=false
+log_stdout=true
+log_stderr=true
+logfile=/var/log/EAPImgRotnWebApp.log
+logfile_maxbytes=10MB
+logfile_backups=2

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ sudo nginx -t
 sudo /etc/nginx/init.d/nginx reload
 ```
 
-### Automating things
+### Automating nginx
 
 Check the status of nginx
 
@@ -44,5 +44,24 @@ sudo systemctl start nginx
 ```
 
 Configure nginx to automatically start on system startup
+```
 sudo systemctl enable nginx
+```
+
+### Run Starlette app on Uvicorn server under supervisor
+
+Included in the directory is a `startServer.sh` bash script that just calls `imgapp.py` in the correct manner. 
+Supervisor should be set up to run this script on startup and in the case of failures. Install and set it up with the following:
+```
+sudo apt-get install supervisor
+cp EAPImgRotnWebApp.conf /etc/supervisor/conf.d / # replace the environment variable with your python path
+sudo service supervisor stop
+sudo service supervisor start
+```
+
+Check supervisor is running the server correctly with 
+```
+sudo supervisorctl
+```
+
  

--- a/nginx_config_file.conf
+++ b/nginx_config_file.conf
@@ -19,7 +19,6 @@ proxy_set_header Host $host;
 proxy_cache_bypass $http_upgrade;
 
 client_max_body_size 0;
-
 }
 
 }

--- a/startServer.sh
+++ b/startServer.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+cd /var/www/EAPImgRotnWebApp
+exec python3 imgapp.py serve


### PR DESCRIPTION
* EAPImgRotnWebApp.conf is the supervisor config file to be copied into
/etc/supervisor/conf.d/
* Updated README with instructions on supervisor setup
* Removed file upload size limit from nginx server config
* Added startServer.sh script used by supervisor to start the uvicorn
server